### PR TITLE
use dune-copasi v1.0.0 tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
       INSTALL_PREFIX: '/opt/smelibs'
       SUDOCMD: 'sudo'
       OS_TARGET: 'linux'
-      USE_FALLBACK_FILESYSTEM: 'OFF'
+      DUNE_USE_FALLBACK_FILESYSTEM: 'OFF'
     defaults:
       run:
         shell: bash
@@ -34,7 +34,7 @@ jobs:
       SUDOCMD: 'sudo'
       MACOSX_DEPLOYMENT_TARGET: '10.14'
       OS_TARGET: 'osx'
-      USE_FALLBACK_FILESYSTEM: 'ON'
+      DUNE_USE_FALLBACK_FILESYSTEM: 'ON'
     defaults:
       run:
         shell: bash
@@ -53,7 +53,7 @@ jobs:
       INSTALL_PREFIX: '/c/smelibs'
       SUDOCMD: ''
       OS_TARGET: 'win64'
-      USE_FALLBACK_FILESYSTEM: 'OFF'
+      DUNE_USE_FALLBACK_FILESYSTEM: 'OFF'
     defaults:
       run:
         shell: msys2 {0}
@@ -63,7 +63,7 @@ jobs:
         with:
           msystem: MINGW64
           update: true
-          install: mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake make git
+          install: mingw-w64-x86_64-gcc mingw-w64-x86_64-cmake make git dos2unix
       - name: Build script
         run: ./build.sh
       - uses: actions/upload-artifact@v2
@@ -77,7 +77,7 @@ jobs:
       INSTALL_PREFIX: '/c/smelibs'
       SUDOCMD: ''
       OS_TARGET: 'win32'
-      USE_FALLBACK_FILESYSTEM: 'OFF'
+      DUNE_USE_FALLBACK_FILESYSTEM: 'OFF'
     defaults:
       run:
         shell: msys2 {0}
@@ -87,7 +87,7 @@ jobs:
         with:
           msystem: MINGW32
           update: true
-          install: mingw-w64-i686-gcc mingw-w64-i686-cmake make git
+          install: mingw-w64-i686-gcc mingw-w64-i686-cmake make git dos2unix
       - name: Build script
         run: ./build.sh
       - uses: actions/upload-artifact@v2

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@ set -e -x
 
 DEPSDIR=${INSTALL_PREFIX}
 
-DUNE_COPASI_VERSION="master"
+DUNE_COPASI_VERSION="v1.0.0"
 
 echo "DUNE_COPASI_VERSION: ${DUNE_COPASI_VERSION}"
 echo "PATH: $PATH"
@@ -34,56 +34,36 @@ else
    ls /opt/smelibs
 fi
 
-echo 'CMAKE_FLAGS=" -G '"'"'Unix Makefiles'"'"'"' > opts.txt
-echo 'CMAKE_FLAGS+=" -DCMAKE_CXX_STANDARD=17 "' >> opts.txt
-echo 'CMAKE_FLAGS+=" -DCMAKE_BUILD_TYPE=Release "' >> opts.txt
-echo 'CMAKE_FLAGS+=" -DCMAKE_INSTALL_PREFIX='"$DEPSDIR"'/dune "' >> opts.txt
-echo 'CMAKE_FLAGS+=" -DGMPXX_INCLUDE_DIR:PATH='"$DEPSDIR"'/include "' >> opts.txt
-echo 'CMAKE_FLAGS+=" -DGMPXX_LIB:FILEPATH='"$DEPSDIR"'/lib/libgmpxx.a "' >> opts.txt
-echo 'CMAKE_FLAGS+=" -DGMP_LIB:FILEPATH='"$DEPSDIR"'/lib/libgmp.a "' >> opts.txt
-echo 'CMAKE_FLAGS+=" -DCMAKE_PREFIX_PATH='"$DEPSDIR"' "' >> opts.txt
-echo 'CMAKE_FLAGS+=" -Dfmt_ROOT='"$DEPSDIR"' "' >> opts.txt
-echo 'CMAKE_FLAGS+=" -DDUNE_PYTHON_VIRTUALENV_SETUP=0 -DDUNE_PYTHON_ALLOW_GET_PIP=0 "' >> opts.txt
-echo 'CMAKE_FLAGS+=" -DCMAKE_DISABLE_FIND_PACKAGE_QuadMath=TRUE -DBUILD_TESTING=OFF "' >> opts.txt
-echo 'CMAKE_FLAGS+=" -DDUNE_USE_ONLY_STATIC_LIBS=ON -DF77=true"' >> opts.txt
-echo 'CMAKE_FLAGS+=" -DDUNE_COPASI_SD_EXECUTABLE=ON"' >> opts.txt
-echo 'CMAKE_FLAGS+=" -DDUNE_COPASI_MD_EXECUTABLE=ON"' >> opts.txt
-echo 'CMAKE_FLAGS+=" -DUSE_FALLBACK_FILESYSTEM='"$USE_FALLBACK_FILESYSTEM"' "' >> opts.txt
+# export vars for duneopts script to read
+export DUNE_COPASI_USE_STATIC_DEPS=ON
+export CMAKE_INSTALL_PREFIX=$DEPSDIR
+export MAKE_FLAGS="-j2 VERBOSE=1"
 if [[ $MSYSTEM ]]; then
-	# on windows add flags to support large object files & statically link libgcc.
-	# https://stackoverflow.com/questions/16596876/object-file-has-too-many-sections
-	echo 'CMAKE_FLAGS+=" -DCMAKE_CXX_FLAGS='"'"'-Wa,-mbig-obj -fvisibility=hidden -fpic -static -static-libgcc -static-libstdc++'"'"' "' >> opts.txt
-else
-    echo 'CMAKE_FLAGS+=" -DCMAKE_CXX_FLAGS='"'"'-fvisibility=hidden -fpic -static-libstdc++'"'"' "' >> opts.txt
+  # on windows add flags to support large object files
+  # https://stackoverflow.com/questions/16596876/object-file-has-too-many-sections
+  export CMAKE_CXX_FLAGS='-Wa,-mbig-obj'
 fi
-echo 'MAKE_FLAGS="-j2 VERBOSE=1"' >> opts.txt
-
-export DUNE_OPTIONS_FILE="opts.txt"
-export DUNECONTROL=./dune-common/bin/dunecontrol
 
 # clone dune-copasi
-git clone -b ${DUNE_COPASI_VERSION} --depth 1 --recursive https://gitlab.dune-project.org/copasi/dune-copasi.git
+git clone -b ${DUNE_COPASI_VERSION} --depth 1 https://gitlab.dune-project.org/copasi/dune-copasi.git
+cd dune-copasi
 
-# setup build
-bash dune-copasi/.ci/setup.sh
+# check opts
+bash dune-copasi.opts
 
-# remove testtools
-rm -rf dune-testtools
+# build & install dune (excluding dune-copasi)
+bash .ci/setup_dune $PWD/dune-copasi.opts
 
-# build
-bash dune-copasi/.ci/build.sh
-
-# install dune-copasi
-$DUNECONTROL bexec $SUDOCMD make install
+# build & install dune-copasi
+bash .ci/install $PWD/dune-copasi.opts
 
 # remove docs & binaries
-$SUDOCMD rm -rf $DEPSDIR/dune/bin
-$SUDOCMD rm -rf $DEPSDIR/dune/share
+$SUDOCMD rm -rf $DEPSDIR/bin
+$SUDOCMD rm -rf $DEPSDIR/share
+ls $DEPSDIR
 
-ls $DEPSDIR/dune
-ls $DEPSDIR/dune/*
-du -sh $DEPSDIR/dune
+cd ..
 
 mkdir artefacts
 cd artefacts
-tar -zcvf sme_deps_dune_${OS_TARGET}.tgz $DEPSDIR/dune/*
+tar -zcvf sme_deps_dune_${OS_TARGET}.tgz $DEPSDIR/*


### PR DESCRIPTION
- install to same place as other deps (for simplicity: avoids PATH_PREFIX parsing issues with dune-copasi ci scripts)
- tarball now contains *all* libs & headers, not just dune